### PR TITLE
Updated HERO API URL

### DIFF
--- a/litter_getter/hero.py
+++ b/litter_getter/hero.py
@@ -14,19 +14,19 @@ GET http://hero.epa.gov/ws/index.cfm/api/1.0/search/heroid/1203
 All query fields are passed as name/value pairs in the URL. For example:
 
 JSON
-http://hero.epa.gov/ws/index.cfm/api/1.0/search/criteria/mercury.json
-http://hero.epa.gov/ws/index.cfm/api/1.0/search/singleyear/1990/any/inhalation
+https://hero.epa.gov/hero/ws/index.cfm/api/1.0/search/criteria/mercury.json
+https://hero.epa.gov/hero/ws/index.cfm/api/1.0/search/singleyear/1990/any/inhalation
 
 XML
-http://hero.epa.gov/ws/index.cfm/api/1.0/search/criteria/mercury.xml
-http://hero.epa.gov/ws/index.cfm/api/1.0/search/singleyear/1990/any/inhalation%20reference.xml
-http://hero.epa.gov/ws/index.cfm/api/1.0/search/singleyear/1990/any/inhalation%20reference/recordsperpage/5.xml
+https://hero.epa.gov/hero/ws/index.cfm/api/1.0/search/criteria/mercury.xml
+https://hero.epa.gov/hero/ws/index.cfm/api/1.0/search/singleyear/1990/any/inhalation%20reference.xml
+https://hero.epa.gov/hero/ws/index.cfm/api/1.0/search/singleyear/1990/any/inhalation%20reference/recordsperpage/5.xml
 
 RIS
-http://hero.epa.gov/ws/index.cfm/api/1.0/search/criteria/mercury.ris
+https://hero.epa.gov/hero/ws/index.cfm/api/1.0/search/criteria/mercury.ris
 
 Getting multiple HERO ids (records per page required)
-http://hero.epa.gov/ws/index.cfm/api/1.0/search/criteria/1200,1201,1203,1204/recordsperpage/500.xml
+https://hero.epa.gov/hero/ws/index.cfm/api/1.0/search/criteria/1200,1201,1203,1204/recordsperpage/500.xml
 
 """
 
@@ -40,7 +40,7 @@ class HEROFetch(object):
     includes the PubMed ID, if available in HERO.
     """
 
-    base_url = r'http://hero.epa.gov/ws/index.cfm/api/1.0/search/criteria/{pks}/recordsperpage/{rpp}.json'  # noqa
+    base_url = r'https://hero.epa.gov/hero/ws/index.cfm/api/1.0/search/criteria/{pks}/recordsperpage/{rpp}.json'  # noqa
     default_settings = {'recordsperpage': 100}
 
     def __init__(self, id_list, **kwargs):

--- a/tests/test_hero.py
+++ b/tests/test_hero.py
@@ -40,9 +40,9 @@ class HEROFetchTests(TestCase):
         ids = [str(d) for d in range(1200, 1405)]
         hero_getter = HEROFetch(id_list=ids)
         hero_getter.get_content()
-        self.assertEqual(len(hero_getter.content), 197)
-        self.assertEqual(len(hero_getter.failures), 8)
+        self.assertEqual(len(hero_getter.content), 200)
+        self.assertEqual(len(hero_getter.failures), 5)
         self.assertListEqual(
             sorted(hero_getter.failures),
-            sorted(['1227', '1349', '1224', '1303', '1205',
-                    '1228', '1373', '1361']))
+            sorted(['1227', '1349', '1224',
+                    '1228', '1361']))


### PR DESCRIPTION
HERO has a new URL scheme, which means the URL for the search API has changed. This updates to the current URL.